### PR TITLE
Standardise cset and encoding arguments; allow UTF8 and UTF-8

### DIFF
--- a/R/H5T.R
+++ b/R/H5T.R
@@ -90,8 +90,11 @@ NULL
 #' @export
 H5Tset_cset <- function( dtype_id, cset = "ASCII") {
   
+  
+  
   cset_int <- switch(cset, 
                      "ASCII" = 0L, 
+                     "UTF8" = 1L,
                      "UTF-8" = 1L, 
                      stop("Invalid value to 'cset' argument.\n",
                           "Valid options are: 'ASCII', 'UTF-8'")) 

--- a/R/h5create.R
+++ b/R/h5create.R
@@ -376,7 +376,7 @@ h5createGroup <- function(file, group) {
 #' @export h5createDataset
 h5createDataset <- function(file, dataset, dims, maxdims = dims, 
                             storage.mode = "double", H5type = NULL, 
-                            size = NULL, encoding = c("ASCII", "UTF-8"),
+                            size = NULL, encoding = NULL,
                             chunk = dims, fillValue, 
                             level = 6, filter = "gzip", shuffle = TRUE,
                             native = FALSE) {
@@ -404,7 +404,8 @@ h5createDataset <- function(file, dataset, dims, maxdims = dims,
   }
   
   ## determine data type
-  tid <- .setDataType(H5type, storage.mode, size, encoding = match.arg(encoding))
+  tid <- .setDataType(H5type, storage.mode, size, 
+                      encoding = match.arg(encoding, choices = c("ASCII", "UTF-8", "UTF8")))
   
   dcpl <- .createDCPL(chunk, dims, level, fillValue, dtype = tid, filter = filter, shuffle = shuffle)
   on.exit(H5Pclose(dcpl), add = TRUE)
@@ -426,62 +427,61 @@ h5createDataset <- function(file, dataset, dims, maxdims = dims,
 }
 
 #' Create HDF5 attribute
-#' 
+#'
 #' R function to create an HDF5 attribute and defining its dimensionality.
-#' 
+#'
 #' Creates a new attribute and attaches it to an existing HDF5 object. The
 #' function will fail, if the file doesn't exist or if there exists already
 #' another attribute with the same name for this object.
-#' 
-#' You can use [h5writeAttribute()] immediately. It will create the
-#' attribute for you.
-#' 
-#' @param obj The name (character) of the object the attribute will be
-#' attatched to. For advanced programmers it is possible to provide an object
-#' of class [H5IdComponent-class] representing a H5 object identifier
-#' (file, group, dataset). See [H5Fcreate()], [H5Fopen()],
-#' [H5Gcreate()], [H5Gopen()], [H5Dcreate()],
-#' [H5Dopen()] to create an object of this kind.
-#' @param file The filename (character) of the file in which the dataset will
-#' be located. For advanced programmers it is possible to provide an object of
-#' class [H5IdComponent-class] representing an H5 location identifier. See
-#' [H5Fcreate()], [H5Fopen()], [H5Gcreate()],
-#' [H5Gopen()] to create an object of this kind. The \code{file}
-#' argument is not required, if the argument \code{obj} is of type
-#' \code{H5IdComponent}.
+#'
+#' You can use [h5writeAttribute()] immediately. It will create the attribute
+#' for you.
+#'
+#' @param obj The name (character) of the object the attribute will be attatched
+#'   to. For advanced programmers it is possible to provide an object of class
+#'   [H5IdComponent-class] representing a H5 object identifier (file, group,
+#'   dataset). See [H5Fcreate()], [H5Fopen()], [H5Gcreate()], [H5Gopen()],
+#'   [H5Dcreate()], [H5Dopen()] to create an object of this kind.
+#' @param file The filename (character) of the file in which the dataset will be
+#'   located. For advanced programmers it is possible to provide an object of
+#'   class [H5IdComponent-class] representing an H5 location identifier. See
+#'   [H5Fcreate()], [H5Fopen()], [H5Gcreate()], [H5Gopen()] to create an object
+#'   of this kind. The \code{file} argument is not required, if the argument
+#'   \code{obj} is of type \code{H5IdComponent}.
 #' @param attr Name of the attribute to be created.
 #' @param dims The dimensions of the attribute as a numeric vector. If
-#' \code{NULL}, a scalar dataspace will be created instead.
+#'   \code{NULL}, a scalar dataspace will be created instead.
 #' @param maxdims The maximum extension of the attribute.
 #' @param storage.mode The storage mode of the data to be written. Can be
-#' obtained by \code{storage.mode(mydata)}.
+#'   obtained by \code{storage.mode(mydata)}.
 #' @param H5type Advanced programmers can specify the datatype of the dataset
-#' within the file. See \code{h5const("H5T")} for a list of available
-#' datatypes. If \code{H5type} is specified the argument \code{storage.mode} is
-#' ignored. It is recommended to use \code{storage.mode}
+#'   within the file. See \code{h5const("H5T")} for a list of available
+#'   datatypes. If \code{H5type} is specified the argument \code{storage.mode}
+#'   is ignored. It is recommended to use \code{storage.mode}
 #' @param size The maximum string length when \code{storage.mode='character'}.
-#' If this is specified, HDF5 stores each string of \code{attr} as fixed length
-#' character arrays. Together with compression, this should be efficient.
-#' 
-#' If this argument is set to \code{NULL}, HDF5 will instead store
-#' variable-length strings.
-#' @param cset The encoding to use when \code{storage.mode='character'}. Valid 
-#' options are "ASCII" or "UTF-8"
+#'   If this is specified, HDF5 stores each string of \code{attr} as fixed
+#'   length character arrays. Together with compression, this should be
+#'   efficient.
+#'
+#'   If this argument is set to \code{NULL}, HDF5 will instead store
+#'   variable-length strings.
+#' @param encoding The encoding of the string data type i.e. when `storage.mode
+#'   = 'character'`. Valid options are "ASCII" and "UTF-8".
+#' @param cset *Deprecated in favour of the `encoding` argument.*
 #' @param native An object of class \code{logical}. If TRUE, array-like objects
-#' are treated as stored in HDF5 row-major rather than R column-major
-#' orientation. Using \code{native = TRUE} increases HDF5 file portability
-#' between programming languages. A file written with \code{native = TRUE}
-#' should also be read with \code{native = TRUE}
+#'   are treated as stored in HDF5 row-major rather than R column-major
+#'   orientation. Using \code{native = TRUE} increases HDF5 file portability
+#'   between programming languages. A file written with \code{native = TRUE}
+#'   should also be read with \code{native = TRUE}
 #' @return Returns TRUE is attribute was created successfully and FALSE
-#' otherwise.
+#'   otherwise.
 #' @author Bernd Fischer
-#' @seealso [h5createFile()], [h5createGroup()],
-#' [h5createDataset()], [h5read()], [h5write()],
-#' \link{rhdf5}
+#' @seealso [h5createFile()], [h5createGroup()], [h5createDataset()],
+#'   [h5read()], [h5write()], \link{rhdf5}
 #' @references \url{https://portal.hdfgroup.org/display/HDF5}
 #' @keywords programming interface IO file
 #' @examples
-#' 
+#'
 #' h5createFile("ex_createAttribute.h5")
 #' h5write(1:1, "ex_createAttribute.h5","A")
 #' fid <- H5Fopen("ex_createAttribute.h5")
@@ -489,13 +489,21 @@ h5createDataset <- function(file, dataset, dims, maxdims = dims,
 #' h5createAttribute (did, "time", c(1,10))
 #' H5Dclose(did)
 #' H5Fclose(fid)
-#' 
+#'
 #' @name h5_createAttribute
 #' @export h5createAttribute
 h5createAttribute <- function(obj, attr, dims, maxdims = dims, file, 
                               storage.mode = "double", H5type = NULL, 
-                              size = NULL, cset = c("ASCII", "UTF-8"),
+                              size = NULL, encoding = NULL, cset = NULL, 
                               native = FALSE) {
+  
+    ## remove the cset argument in BioC 3.16
+    if(!is.null(cset)) {
+      if(is.null(encoding)) 
+        encoding <- cset
+      message("The 'cset' argument has been deprecated.\n",
+              "Please use the argument 'encoding' instead.")
+    }
     
     obj = h5checktypeOrOpenObj(obj, file, native = native)
     on.exit(h5closeitObj(obj))
@@ -521,7 +529,8 @@ h5createAttribute <- function(obj, attr, dims, maxdims = dims, file,
                           integer = h5constants$H5T["H5T_STD_I32LE"],
                           character = {
                               tid <- H5Tcopy("H5T_C_S1")
-                              H5Tset_cset(tid, match.arg(cset))
+                              H5Tset_cset(tid, cset = match.arg(encoding, 
+                                                                choices = c("ASCII", "UTF-8", "UTF8")))
                               if (!is.null(size) && !is.numeric(size)) {
                                 stop("'size' should be NULL or a number when 'storage.mode=\"character\"'")
                               }

--- a/R/h5write.R
+++ b/R/h5write.R
@@ -304,7 +304,7 @@ h5writeDataset.raw       <- function(...) { h5writeDataset.array(...) }
 #' @export 
 h5writeDataset.array <- function(obj, h5loc, name, index = NULL, 
                                  start=NULL, stride=NULL, block=NULL, count=NULL, 
-                                 size=NULL, variableLengthString=FALSE, encoding=c("ASCII", "UTF-8"),
+                                 size=NULL, variableLengthString=FALSE, encoding = NULL,
                                  level=6) {
 
     exists <- try( { H5Lexists(h5loc, name) } )
@@ -327,7 +327,8 @@ h5writeDataset.array <- function(obj, h5loc, name, index = NULL,
             if (h5loc@native) dim <- rev(dim)
         }
         h5createDataset(h5loc, name, dim, storage.mode = storage.mode(obj), 
-                        size = size, encoding = match.arg(encoding),
+                        size = size, 
+                        encoding = match.arg(encoding, choices = c("ASCII", "UTF-8", "UTF8")),
                         chunk=dim, level=level) 
     }
     h5dataset <- H5Dopen(h5loc, name)

--- a/R/h5writeAttr.R
+++ b/R/h5writeAttr.R
@@ -1,5 +1,5 @@
-#' Write an R object as an HDF5 attribute 
-#' 
+#' Write an R object as an HDF5 attribute
+#'
 #' @param attr The R object to be written as an HDF5 attribute.
 #' @param h5obj An object of class [H5IdComponent-class] representing a H5
 #'   object identifier (file, group, or dataset). See \code{\link{H5Fcreate}},
@@ -7,15 +7,27 @@
 #'   \code{\link{H5Dcreate}}, or \code{\link{H5Dopen}} to create an object of
 #'   this kind.
 #' @param name The name of the attribute to be written.
-#' @param cset The encoding of the string data type.
+#' @param encoding The encoding of the string data type. Valid options are
+#'   "ASCII" and "UTF-8".
+#' @param cset *Deprecated in favour of the `encoding` argument.*
 #' @param variableLengthString Whether character vectors should be written as
 #'   variable-length strings into the attributes.
 #' @param asScalar Whether length-1 \code{attr} should be written into a scalar
 #'   dataspace.
-#'   
+#'
 #' @name h5_writeAttribute
 #' @export
-h5writeAttribute <- function(attr, h5obj, name, cset=c("ASCII", "UTF8"), variableLengthString=FALSE, asScalar=FALSE) {
+h5writeAttribute <- function(attr, h5obj, name, encoding = NULL, cset = NULL,
+                             variableLengthString=FALSE, asScalar=FALSE) {
+  
+  ## remove the cset argument in BioC 3.16
+  if(!is.null(cset)) {
+    if(is.null(encoding)) 
+      encoding <- cset
+    message("The 'cset' argument has been deprecated.\n",
+            "Please use the argument 'encoding' instead.")
+  }
+  
   h5checktype(h5obj, "object")
   if (is(attr, "H5IdComponent"))
     res <- h5writeAttribute.array(attr, h5obj, name, asScalar=TRUE)
@@ -38,7 +50,8 @@ h5writeAttribute.character <- function(...) { h5writeAttribute.array(...) }
 h5writeAttribute.default <- function(attr, h5obj, name, ...) { warning("No function found to write attribute of class '",class(attr),"'. Attribute '",name,"' is not written to hdf5-file.") }
 
 #' @rdname h5_writeAttribute
-h5writeAttribute.array <- function(attr, h5obj, name, cset=c("ASCII", "UTF8"), variableLengthString=FALSE, asScalar=FALSE) {
+h5writeAttribute.array <- function(attr, h5obj, name, encoding = NULL, cset=NULL, 
+                                   variableLengthString=FALSE, asScalar=FALSE) {
   if (asScalar) {
     if (length(attr) != 1L) {
       stop("cannot use 'asScalar=TRUE' when 'length(attr) > 1'")
@@ -62,7 +75,9 @@ h5writeAttribute.array <- function(attr, h5obj, name, cset=c("ASCII", "UTF8"), v
   storagemode <- storage.mode(attr)
   if (storagemode == "S4" && is(attr, "H5IdComponent"))
     storagemode <- "H5IdComponent"
-  h5createAttribute(h5obj, name, dims = dims, storage.mode = storagemode, size = size, cset=match.arg(cset))
+  h5createAttribute(h5obj, name, dims = dims, storage.mode = storagemode, 
+                    size = size, 
+                    encoding = match.arg(encoding, choices = c("ASCII", "UTF-8", "UTF8")))
   h5attr <- H5Aopen(h5obj, name)
 
   DimMem <- dim(attr)

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -9,6 +9,25 @@
       references.
     }
   }
+  
+  \subsection{CHANGES}{
+    \itemize{
+      \item Argument 'cset' to \code{h5createAttribute()} and 
+      \code{h5writeAttribute()} have been deprecated.  The 'encoding'
+      argument should be used going forward.  This ensures consistency with 
+      \code{h5create()} and \code{h5write()}.
+    }
+  }
+  
+  \subsection{BUG FIXES}{
+    \itemize{
+      \item The documentation for the 'encoding' argument to 
+      \code{h5createDataset()} and \code{h5writeDataset()} 'UTF-8' was a valid
+      option, however this would produce an error. This has now been fixed.
+      (Thanks to @ilia-kats for identifying this, 
+      https://github.com/grimbough/rhdf5/pull/101)
+    }
+  }
 
 }
 

--- a/man/h5_createAttribute.Rd
+++ b/man/h5_createAttribute.Rd
@@ -14,7 +14,7 @@ h5createAttribute(
   storage.mode = "double",
   H5type = NULL,
   size = NULL,
-  cset = c("ASCII", "UTF8"),
+  cset = c("ASCII", "UTF-8"),
   native = FALSE
 )
 }
@@ -56,7 +56,8 @@ character arrays. Together with compression, this should be efficient.
 If this argument is set to \code{NULL}, HDF5 will instead store
 variable-length strings.}
 
-\item{cset}{The encoding to use when \code{storage.mode='character'}.}
+\item{cset}{The encoding to use when \code{storage.mode='character'}. Valid
+options are "ASCII" or "UTF-8"}
 
 \item{native}{An object of class \code{logical}. If TRUE, array-like objects
 are treated as stored in HDF5 row-major rather than R column-major

--- a/man/h5_createAttribute.Rd
+++ b/man/h5_createAttribute.Rd
@@ -14,17 +14,17 @@ h5createAttribute(
   storage.mode = "double",
   H5type = NULL,
   size = NULL,
-  cset = c("ASCII", "UTF-8"),
+  encoding = NULL,
+  cset = NULL,
   native = FALSE
 )
 }
 \arguments{
-\item{obj}{The name (character) of the object the attribute will be
-attatched to. For advanced programmers it is possible to provide an object
-of class \linkS4class{H5IdComponent} representing a H5 object identifier
-(file, group, dataset). See \code{\link[=H5Fcreate]{H5Fcreate()}}, \code{\link[=H5Fopen]{H5Fopen()}},
-\code{\link[=H5Gcreate]{H5Gcreate()}}, \code{\link[=H5Gopen]{H5Gopen()}}, \code{\link[=H5Dcreate]{H5Dcreate()}},
-\code{\link[=H5Dopen]{H5Dopen()}} to create an object of this kind.}
+\item{obj}{The name (character) of the object the attribute will be attatched
+to. For advanced programmers it is possible to provide an object of class
+\linkS4class{H5IdComponent} representing a H5 object identifier (file, group,
+dataset). See \code{\link[=H5Fcreate]{H5Fcreate()}}, \code{\link[=H5Fopen]{H5Fopen()}}, \code{\link[=H5Gcreate]{H5Gcreate()}}, \code{\link[=H5Gopen]{H5Gopen()}},
+\code{\link[=H5Dcreate]{H5Dcreate()}}, \code{\link[=H5Dopen]{H5Dopen()}} to create an object of this kind.}
 
 \item{attr}{Name of the attribute to be created.}
 
@@ -33,31 +33,32 @@ of class \linkS4class{H5IdComponent} representing a H5 object identifier
 
 \item{maxdims}{The maximum extension of the attribute.}
 
-\item{file}{The filename (character) of the file in which the dataset will
-be located. For advanced programmers it is possible to provide an object of
+\item{file}{The filename (character) of the file in which the dataset will be
+located. For advanced programmers it is possible to provide an object of
 class \linkS4class{H5IdComponent} representing an H5 location identifier. See
-\code{\link[=H5Fcreate]{H5Fcreate()}}, \code{\link[=H5Fopen]{H5Fopen()}}, \code{\link[=H5Gcreate]{H5Gcreate()}},
-\code{\link[=H5Gopen]{H5Gopen()}} to create an object of this kind. The \code{file}
-argument is not required, if the argument \code{obj} is of type
-\code{H5IdComponent}.}
+\code{\link[=H5Fcreate]{H5Fcreate()}}, \code{\link[=H5Fopen]{H5Fopen()}}, \code{\link[=H5Gcreate]{H5Gcreate()}}, \code{\link[=H5Gopen]{H5Gopen()}} to create an object
+of this kind. The \code{file} argument is not required, if the argument
+\code{obj} is of type \code{H5IdComponent}.}
 
 \item{storage.mode}{The storage mode of the data to be written. Can be
 obtained by \code{storage.mode(mydata)}.}
 
 \item{H5type}{Advanced programmers can specify the datatype of the dataset
 within the file. See \code{h5const("H5T")} for a list of available
-datatypes. If \code{H5type} is specified the argument \code{storage.mode} is
-ignored. It is recommended to use \code{storage.mode}}
+datatypes. If \code{H5type} is specified the argument \code{storage.mode}
+is ignored. It is recommended to use \code{storage.mode}}
 
 \item{size}{The maximum string length when \code{storage.mode='character'}.
-If this is specified, HDF5 stores each string of \code{attr} as fixed length
-character arrays. Together with compression, this should be efficient.
+If this is specified, HDF5 stores each string of \code{attr} as fixed
+length character arrays. Together with compression, this should be
+efficient.
 
 If this argument is set to \code{NULL}, HDF5 will instead store
 variable-length strings.}
 
-\item{cset}{The encoding to use when \code{storage.mode='character'}. Valid
-options are "ASCII" or "UTF-8"}
+\item{encoding}{The encoding of the string data type i.e. when \code{storage.mode = 'character'}. Valid options are "ASCII" and "UTF-8".}
+
+\item{cset}{\emph{Deprecated in favour of the \code{encoding} argument.}}
 
 \item{native}{An object of class \code{logical}. If TRUE, array-like objects
 are treated as stored in HDF5 row-major rather than R column-major
@@ -77,8 +78,8 @@ Creates a new attribute and attaches it to an existing HDF5 object. The
 function will fail, if the file doesn't exist or if there exists already
 another attribute with the same name for this object.
 
-You can use \code{\link[=h5writeAttribute]{h5writeAttribute()}} immediately. It will create the
-attribute for you.
+You can use \code{\link[=h5writeAttribute]{h5writeAttribute()}} immediately. It will create the attribute
+for you.
 }
 \examples{
 
@@ -95,9 +96,8 @@ H5Fclose(fid)
 \url{https://portal.hdfgroup.org/display/HDF5}
 }
 \seealso{
-\code{\link[=h5createFile]{h5createFile()}}, \code{\link[=h5createGroup]{h5createGroup()}},
-\code{\link[=h5createDataset]{h5createDataset()}}, \code{\link[=h5read]{h5read()}}, \code{\link[=h5write]{h5write()}},
-\link{rhdf5}
+\code{\link[=h5createFile]{h5createFile()}}, \code{\link[=h5createGroup]{h5createGroup()}}, \code{\link[=h5createDataset]{h5createDataset()}},
+\code{\link[=h5read]{h5read()}}, \code{\link[=h5write]{h5write()}}, \link{rhdf5}
 }
 \author{
 Bernd Fischer

--- a/man/h5_createDataset.Rd
+++ b/man/h5_createDataset.Rd
@@ -13,7 +13,7 @@ h5createDataset(
   storage.mode = "double",
   H5type = NULL,
   size = NULL,
-  encoding = c("ASCII", "UTF-8"),
+  encoding = NULL,
   chunk = dims,
   fillValue,
   level = 6,

--- a/man/h5_write.Rd
+++ b/man/h5_write.Rd
@@ -36,7 +36,7 @@ h5writeDataset(obj, h5loc, name, ...)
   count = NULL,
   size = NULL,
   variableLengthString = FALSE,
-  encoding = c("ASCII", "UTF-8"),
+  encoding = NULL,
   level = 6
 )
 }

--- a/man/h5_writeAttribute.Rd
+++ b/man/h5_writeAttribute.Rd
@@ -10,7 +10,8 @@ h5writeAttribute(
   attr,
   h5obj,
   name,
-  cset = c("ASCII", "UTF8"),
+  encoding = NULL,
+  cset = NULL,
   variableLengthString = FALSE,
   asScalar = FALSE
 )
@@ -19,7 +20,8 @@ h5writeAttribute(
   attr,
   h5obj,
   name,
-  cset = c("ASCII", "UTF8"),
+  encoding = NULL,
+  cset = NULL,
   variableLengthString = FALSE,
   asScalar = FALSE
 )
@@ -35,7 +37,10 @@ this kind.}
 
 \item{name}{The name of the attribute to be written.}
 
-\item{cset}{The encoding of the string data type.}
+\item{encoding}{The encoding of the string data type. Valid options are
+"ASCII" and "UTF-8".}
+
+\item{cset}{\emph{Deprecated in favour of the \code{encoding} argument.}}
 
 \item{variableLengthString}{Whether character vectors should be written as
 variable-length strings into the attributes.}

--- a/tests/testthat/test_h5create.R
+++ b/tests/testthat/test_h5create.R
@@ -284,7 +284,7 @@ test_that("string encoding is handled properly", {
 
     # Now Unicode.
     h5createAttribute(file = h5File, obj = "foo", dims = c(1,1), attr = "utf_str_attr", 
-                      storage.mode = "character", cset="UTF8", size = NULL)
+                      storage.mode = "character", cset="UTF-8", size = NULL)
     
     fhandle <- H5Fopen(h5File)
     dhandle <- H5Dopen(fhandle, "foo")

--- a/tests/testthat/test_h5writeAttributes.R
+++ b/tests/testthat/test_h5writeAttributes.R
@@ -104,26 +104,34 @@ test_that("Checking other string options when adding attributes", {
 
     ## variable strings
     attr <- "blah"
-    h5writeAttribute(attr = attr, h5obj = gid, name = "char_attr", variableLengthString = TRUE)
+    expect_silent(h5writeAttribute(attr = attr, h5obj = gid, name = "char_attr", 
+                                   variableLengthString = TRUE))
     
     ## different encoding
     attr <- "blah2"
-    h5writeAttribute(attr = attr, h5obj = gid, name = "char_attr2", cset = "UTF8")
+    expect_silent(h5writeAttribute(attr = attr, h5obj = gid, name = "char_attr2", 
+                                   encoding = "UTF-8"))
 
     ## as a scalar
     attr <- "blah3"
-    h5writeAttribute(attr = attr, h5obj = gid, name = "char_attr3", cset = "UTF8", asScalar = TRUE)
-    expect_error(h5writeAttribute(attr = c(attr, attr), h5obj = gid, name = "char_attr3", cset = "UTF8", asScalar = TRUE), "cannot use")
+    expect_silent(h5writeAttribute(attr = attr, h5obj = gid, name = "char_attr3", 
+                                   encoding = "UTF-8", asScalar = TRUE)) 
+    expect_error(h5writeAttribute(attr = c(attr, attr), h5obj = gid, name = "char_attr3", 
+                                  encoding = "UTF-8", asScalar = TRUE), "cannot use")
 
+    ## expect a message telling us this argument is deprecated
+    attr <- "blah4"
+    expect_message(h5writeAttribute(attr = attr, h5obj = gid, name = "char_attr4", cset = "UTF-8"))
+    
     H5Gclose(gid)
     H5Fclose(fid)
 
     attr_back <- h5readAttributes(h5File, name = "blah_group")
-    expect_length(attr_back, n = 3)
+    expect_length(attr_back, n = 4)
 
-    expected <- c("char_attr", "char_attr2", "char_attr3")
+    expected <- c("char_attr", "char_attr2", "char_attr3", "char_attr4")
     expect_identical(sort(expected), sort(names(attr_back)))
-    expect_identical(unname(unlist(attr_back[expected])), c("blah", "blah2", "blah3"))
+    expect_identical(unname(unlist(attr_back[expected])), c("blah", "blah2", "blah3", "blah4"))
 })
 
 test_that("Unable to add logical attribute", {


### PR DESCRIPTION
I've made a few additional changes that should allow both "UTF8" and "UTF-8" to work, just in case there's someone out there using the old notation. I think the old style worked when creating an attribute even if it was broken for datasets, and I'd rather just silently accept both in that case. The manual pages will state "UTF-8" is the correct format, but I think I'll allow "UTF8" without any sort of warning or planned deprecation.

I've also added an `encoding` argument to `h5createAttribute()` and `h5writeAttribute()`.  This standardises with the analogous dataset functions and should be used in preference to `cset`.  `cset` will still work, but you'll get a deprecation message printed and it'll be removed at some point in the future.

Let me know if any of that doesn't behave as you'd expect.